### PR TITLE
Fix home route path

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -48,7 +48,7 @@ function App() {
                     <Navigation />
                     <div className="container mx-auto px-4 py-8">
                       <Routes>
-                        <Route path="/\" element={<Home />} />
+                        <Route path="/" element={<Home />} />
                         <Route
                           path="/atvik"
                           element={


### PR DESCRIPTION
## Summary
- ensure Home component route uses `/` as path

## Testing
- `npm run lint` *(fails: 'process' is not defined, 'toast' is defined but never used, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_683f97a6db18832b9e323dce083c2671