### PR TITLE
Rewrite API routes for Vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -6,7 +6,7 @@
   "rewrites": [
     {
       "source": "/api/(.*)",
-      "destination": "/api/index.js"
+      "destination": "/api/verify-turnstyle.js"
     },
     {
       "source": "/(.*)",


### PR DESCRIPTION
## Summary
- rewrite all `/api/(.*)` routes to `/api/verify-turnstyle.js`

## Testing
- `npm run lint` *(fails: `process is not defined` and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_683f97aa5b9c832bb15dde400d6d4961