### PR TITLE
Add Vitest and API tests

### DIFF
--- a/api/verify-turnstyle.test.js
+++ b/api/verify-turnstyle.test.js
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import handler from './verify-turnstyle.js';
+
+// Simple helper to create mock response object
+function createRes() {
+  return {
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn()
+  };
+}
+
+describe('verify-turnstyle API', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns 405 for GET requests', async () => {
+    const req = { method: 'GET' };
+    const res = createRes();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(405);
+    expect(res.json).toHaveBeenCalledWith({ message: 'Method Not Allowed' });
+  });
+
+  it('returns 200 on successful POST', async () => {
+    const req = {
+      method: 'POST',
+      body: { token: 'token', email: 'test@example.com', password: 'pw' }
+    };
+    const res = createRes();
+
+    global.fetch = vi.fn()
+      .mockResolvedValueOnce({
+        json: vi.fn().mockResolvedValue({ success: true })
+      })
+      .mockResolvedValueOnce({
+        json: vi.fn().mockResolvedValue({})
+      });
+
+    process.env.TURNSTILE_SECRET_KEY = 'secret';
+    process.env.SUPABASE_URL = 'https://example.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'service_key';
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ message: 'Signup successful!' });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test": "vitest"
   },
   "dependencies": {
     "react": "^19.1.0",
@@ -15,6 +16,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",
+    "@testing-library/react": "^16.3.0",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
     "@vitejs/plugin-react": "^4.4.1",
@@ -22,6 +24,8 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^16.0.0",
-    "vite": "^6.3.5"
+    "jsdom": "^26.1.0",
+    "vite": "^6.3.5",
+    "vitest": "^3.2.1"
   }
 }


### PR DESCRIPTION
## Summary
- add Vitest and react testing library deps
- add test script
- add verify-turnstyle API test covering GET and successful POST

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_683f8a2675a0832b90770faa26362afe