### PR TITLE
Add Unauthorized page and route

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,7 @@ import IncidentDashboard from './IncidentDashboard.jsx';
 import GoalsDashboard from './GoalsDashboard.jsx';
 import GoalUpdateForm from './GoalUpdateForm.jsx';
 import GoalProgressChart from './GoalProgressChart.jsx';
+import Unauthorized from './Unauthorized.jsx';
 import { ManagerDashboard } from './components/ManagerDashboard.jsx';
 import { PrivateRoute } from './components/PrivateRoute.jsx';
 import { Navigation } from './components/Navigation.jsx';
@@ -40,6 +41,7 @@ function App() {
           <Routes>
             <Route path="/login" element={<Login />} />
             <Route path="/signup" element={<SignUp />} />
+            <Route path="/unauthorized" element={<Unauthorized />} />
             <Route
               path="/*"
               element={

--- a/src/Unauthorized.jsx
+++ b/src/Unauthorized.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default function Unauthorized() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <div className="bg-white p-8 rounded shadow text-center">
+        <h1 className="text-2xl font-bold mb-4">Aðgangi hafnað</h1>
+        <p className="text-gray-600">Þú hefur ekki réttindi til að skoða þessa síðu.</p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a simple `Unauthorized` page
- register `/unauthorized` route in `App.jsx`

## Testing
- `npm run lint` *(fails: 'process' is not defined etc.)*

------
https://chatgpt.com/codex/tasks/task_e_683f8e48cc70832b88774996c0a3df59