### PR TITLE
Fix unauthorized redirect in PrivateRoute

### DIFF
--- a/src/components/PrivateRoute.jsx
+++ b/src/components/PrivateRoute.jsx
@@ -21,7 +21,9 @@ export function PrivateRoute({ children, requireManager = false }) {
   }
 
   if (requireManager && !isManager) {
-    return <Navigate to="/unauthorized\" state={{ from: location }} replace />;
+    return (
+      <Navigate to="/unauthorized" state={{ from: location }} replace />
+    );
   }
 
   return children;


### PR DESCRIPTION
## Summary
- fix broken path in `PrivateRoute.jsx`

## Testing
- `npm run lint` *(fails: 'process' is not defined and other lint errors)*
- `npm run build` *(fails: cannot resolve /src/main.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_683f87e545b8832b90730e9a3130b519