### PR TITLE
Add offline support for incidents

### DIFF
--- a/src/IncidentDashboard.jsx
+++ b/src/IncidentDashboard.jsx
@@ -25,10 +25,17 @@ export default function IncidentDashboard() {
       if (error) throw error;
 
       setIncidents(data || []);
+      localStorage.setItem('offlineIncidents', JSON.stringify(data || []));
       setErrorState(false);
     } catch (error) {
       console.error('🧨 Incident Load Error:', error.message || error);
-      setErrorState(true);
+      const offline = JSON.parse(localStorage.getItem('offlineIncidents') || '[]');
+      if (offline.length) {
+        setIncidents(offline);
+        setErrorState(false);
+      } else {
+        setErrorState(true);
+      }
     } finally {
       setLoading(false);
     }

--- a/src/IncidentForm.jsx
+++ b/src/IncidentForm.jsx
@@ -4,7 +4,7 @@ import { useAuth } from './hooks/useAuth';
 import toast from 'react-hot-toast';
 
 export default function IncidentForm() {
-  const { user } = useAuth();
+  const { user, profile } = useAuth();
   const [clients, setClients] = useState([]);
   const [formData, setFormData] = useState({
     clientId: '',
@@ -80,7 +80,22 @@ export default function IncidentForm() {
       if (error) throw error;
 
       toast.success('Incident recorded successfully');
-      
+
+      // Save a local copy for offline access
+      const offline = JSON.parse(localStorage.getItem('offlineIncidents') || '[]');
+      offline.unshift({
+        id: Date.now(),
+        created_at: new Date().toISOString(),
+        client_id: formData.clientId,
+        category: formData.category,
+        description: formData.description,
+        reflection: formData.reflection,
+        serious: formData.serious,
+        submitted_by: user.id,
+        user_profiles: { full_name: profile?.full_name || '' }
+      });
+      localStorage.setItem('offlineIncidents', JSON.stringify(offline));
+
       // Reset form
       setFormData({
         clientId: '',

--- a/src/components/ManagerDashboard.jsx
+++ b/src/components/ManagerDashboard.jsx
@@ -48,9 +48,15 @@ export function ManagerDashboard() {
       query = query.eq('category', selectedCategory);
     }
 
-    const { data, error } = await query;
-    if (error) throw error;
-    return data;
+    try {
+      const { data, error } = await query;
+      if (error) throw error;
+      localStorage.setItem('offlineIncidents', JSON.stringify(data || []));
+      return data;
+    } catch (err) {
+      const offline = JSON.parse(localStorage.getItem('offlineIncidents') || '[]');
+      return offline;
+    }
   });
 
   const { data: goals } = useQuery('goals', async () => {


### PR DESCRIPTION
## Summary
- cache incidents locally on create
- load cached incidents when supabase fails
- show incident data in Yfirlit even offline

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6840d5cb73b0832b83d83b758a34d981