### PR TITLE
Add start script for StackBlitz preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "start": "vite",
     "build": "vite build",
     "preview": "vite preview",
     "lint": "eslint .",


### PR DESCRIPTION
## Summary
- add a `start` script so the StackBlitz preview can launch

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6840d881c600832badad47811b811954