### PR TITLE
Support NEXT_PUBLIC env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ The project is configured for deployment on Vercel. Environment variables for Su
 | `VITE_TURNSTILE_SITE_KEY` | Cloudflare Turnstile site key |
 | `TURNSTILE_SECRET_KEY` | Cloudflare Turnstile secret key |
 
+Both Vite (`VITE_`) and Next.js (`NEXT_PUBLIC_`) prefixes are supported for the
+Supabase credentials. Pick the prefix that matches your build tooling and keep
+the same values across environments.
+
 When running on StackBlitz or locally, place these values in a `.env` file. On Vercel set them in your project settings.
 
 ## License

--- a/src/supabase.js
+++ b/src/supabase.js
@@ -2,8 +2,14 @@
 import { createClient } from '@supabase/supabase-js';
 
 // Read credentials from environment variables
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+// Support both Vite (`VITE_*`) and Next.js (`NEXT_PUBLIC_*`) prefixes so the
+// same build can run in different environments without changes.
+const supabaseUrl =
+  import.meta.env.VITE_SUPABASE_URL ||
+  import.meta.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseAnonKey =
+  import.meta.env.VITE_SUPABASE_ANON_KEY ||
+  import.meta.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
 // Fallback + error warning for environments like Vercel or Netlify
 if (!supabaseUrl || !supabaseAnonKey) {


### PR DESCRIPTION
## Summary
- support both `VITE_` and `NEXT_PUBLIC_` prefixes in the Supabase client
- document the environment variable prefix option in the README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6840e806ca90832b84b5219dcc579afc