### PR TITLE
Sync profile after signup

### DIFF
--- a/api/verify-turnstile.js
+++ b/api/verify-turnstile.js
@@ -53,5 +53,24 @@ export default async function handler(req, res) {
     return res.status(400).json({ message: signupJson.error.message });
   }
 
+  // 3. Update user profile with provided full name and role
+  try {
+    const userId = signupJson.user?.id;
+    if (userId) {
+      await fetch(`${SUPABASE_URL}/rest/v1/user_profiles?id=eq.${userId}`, {
+        method: 'PATCH',
+        headers: {
+          apikey: process.env.SUPABASE_SERVICE_ROLE_KEY,
+          Authorization: `Bearer ${process.env.SUPABASE_SERVICE_ROLE_KEY}`,
+          'Content-Type': 'application/json',
+          Prefer: 'return=representation'
+        },
+        body: JSON.stringify({ full_name: fullName, role })
+      });
+    }
+  } catch (err) {
+    console.error('Failed to update user profile:', err);
+  }
+
   return res.status(200).json({ message: 'Signup successful', user: signupJson.user });
 }

--- a/api/verify-turnstyle.test.js
+++ b/api/verify-turnstyle.test.js
@@ -44,6 +44,9 @@ describe('verify-turnstyle API', () => {
         json: vi.fn().mockResolvedValue({ success: true })
       })
       .mockResolvedValueOnce({
+        json: vi.fn().mockResolvedValue({ user: { id: '123' } })
+      })
+      .mockResolvedValueOnce({
         json: vi.fn().mockResolvedValue({})
       });
 
@@ -53,7 +56,11 @@ describe('verify-turnstyle API', () => {
 
     await handler(req, res);
 
+    expect(global.fetch).toHaveBeenCalledTimes(3);
     expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.json).toHaveBeenCalledWith({ message: 'Signup successful' });
+    expect(res.json).toHaveBeenCalledWith({
+      message: 'Signup successful',
+      user: { id: '123' }
+    });
   });
 });


### PR DESCRIPTION
## Summary
- update signup API to write a user profile after creating an auth user
- adjust tests for the additional API call

## Testing
- `npm run lint`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6841002aab18832ba4c8346fcf77d429