### PR TITLE
Add user_roles table migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ npm test
 - `api/` – Serverless functions used in development and on Vercel
 - `supabase/` – Supabase migrations and seed scripts
 
+### Database Schema
+
+Supabase migrations create tables such as `user_profiles`, `clients`, `incidents`, `goals` and `goal_updates`. A new table `user_roles` mirrors the role of each profile and is kept in sync via a trigger so policies can safely reference it.
+
 ## Deployment
 
 The project is configured for deployment on Vercel. Environment variables for Supabase and Turnstile should be set in the Vercel dashboard.

--- a/supabase/migrations/20250604060000_add_user_roles.sql
+++ b/supabase/migrations/20250604060000_add_user_roles.sql
@@ -1,0 +1,51 @@
+/*
+  # Add user_roles table
+
+  1. Changes
+    - create table mapping users to roles
+    - seed from existing user_profiles
+    - trigger to keep roles in sync
+    - enable RLS with policy for users to read their role
+
+  2. Security
+    - ensures policies referencing user_roles function correctly
+*/
+
+-- Create table if missing
+CREATE TABLE IF NOT EXISTS user_roles (
+  id uuid PRIMARY KEY REFERENCES user_profiles(id) ON DELETE CASCADE,
+  role text NOT NULL CHECK (role IN ('employee', 'manager')),
+  created_at timestamptz DEFAULT now()
+);
+
+-- Populate with current roles
+INSERT INTO user_roles (id, role)
+SELECT id, role FROM user_profiles
+ON CONFLICT (id) DO NOTHING;
+
+-- Function to sync changes from user_profiles
+CREATE OR REPLACE FUNCTION sync_user_roles()
+RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO user_roles(id, role)
+  VALUES (NEW.id, NEW.role)
+  ON CONFLICT (id) DO UPDATE SET role = EXCLUDED.role;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Trigger for inserts and updates on user_profiles
+DROP TRIGGER IF EXISTS trg_sync_user_roles ON user_profiles;
+CREATE TRIGGER trg_sync_user_roles
+AFTER INSERT OR UPDATE OF role ON user_profiles
+FOR EACH ROW
+EXECUTE FUNCTION sync_user_roles();
+
+-- Row level security
+ALTER TABLE user_roles ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "User can read own role" ON user_roles;
+CREATE POLICY "User can read own role"
+  ON user_roles
+  FOR SELECT
+  TO authenticated
+  USING (auth.uid() = id);


### PR DESCRIPTION
## Summary
- create `user_roles` table with sync trigger
- update README with a brief schema overview

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684108260ff8832b818883b0bece44f1