### PR TITLE
Skip user_roles policy until table exists

### DIFF
--- a/supabase/migrations/20250603103548_ancient_wind.sql
+++ b/supabase/migrations/20250603103548_ancient_wind.sql
@@ -45,9 +45,6 @@ ALTER POLICY "Users can read own incidents"
     )
   );
 
-ALTER POLICY "User can read own role" 
-  ON public.user_roles
-  USING (auth.role() = 'authenticated' AND auth.uid() = id);
 
 -- Add explicit INSERT policies with authentication checks
 ALTER POLICY "Users can create incidents" 


### PR DESCRIPTION
## Summary
- remove `User can read own role` policy from `20250603103548_ancient_wind.sql`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684253e83d4c832bb0f9397a65899ea4