### PR TITLE
Fix co_staff migrations

### DIFF
--- a/supabase/migrations/20250604050243_throbbing_dawn.sql
+++ b/supabase/migrations/20250604050243_throbbing_dawn.sql
@@ -19,6 +19,14 @@ CREATE TEMPORARY TABLE temp_incidents AS SELECT id, co_staff FROM incidents;
 ALTER TABLE incidents DROP COLUMN co_staff;
 ALTER TABLE incidents ADD COLUMN co_staff uuid[];
 
+-- Migrate data back into the new column
+UPDATE incidents i
+SET co_staff = t.co_staff::uuid[]
+FROM temp_incidents t
+WHERE i.id = t.id;
+
+DROP TABLE temp_incidents;
+
 -- Update the employees policy to handle UUID comparison correctly
 DROP POLICY IF EXISTS "Employees can view assigned incidents" ON incidents;
 CREATE POLICY "Employees can view assigned incidents"

--- a/supabase/migrations/20250604050357_dawn_sea.sql
+++ b/supabase/migrations/20250604050357_dawn_sea.sql
@@ -22,12 +22,20 @@ CREATE TABLE IF NOT EXISTS role_change_log (
 );
 
 -- Create temporary table to store co_staff data
-CREATE TEMPORARY TABLE temp_incidents AS 
+CREATE TEMPORARY TABLE temp_incidents AS
 SELECT id, co_staff FROM incidents;
 
 -- Modify co_staff to be UUID array
 ALTER TABLE incidents DROP COLUMN co_staff;
 ALTER TABLE incidents ADD COLUMN co_staff uuid[] DEFAULT '{}';
+
+-- Restore previous co_staff values
+UPDATE incidents i
+SET co_staff = t.co_staff::uuid[]
+FROM temp_incidents t
+WHERE i.id = t.id;
+
+DROP TABLE temp_incidents;
 
 -- Add index for co_staff array
 CREATE INDEX IF NOT EXISTS idx_incidents_co_staff ON incidents USING gin(co_staff);

--- a/supabase/migrations/20250604050504_crystal_plain.sql
+++ b/supabase/migrations/20250604050504_crystal_plain.sql
@@ -29,12 +29,20 @@ DROP POLICY IF EXISTS "Users can read own incidents" ON incidents;
 DROP POLICY IF EXISTS "Managers can view all incidents" ON incidents;
 
 -- Create temporary table to store co_staff data
-CREATE TEMPORARY TABLE temp_incidents AS 
+CREATE TEMPORARY TABLE temp_incidents AS
 SELECT id, co_staff FROM incidents;
 
 -- Modify co_staff to be UUID array
 ALTER TABLE incidents DROP COLUMN co_staff;
 ALTER TABLE incidents ADD COLUMN co_staff uuid[] DEFAULT '{}';
+
+-- Reinsert previous co_staff values
+UPDATE incidents i
+SET co_staff = t.co_staff::uuid[]
+FROM temp_incidents t
+WHERE i.id = t.id;
+
+DROP TABLE temp_incidents;
 
 -- Add index for co_staff array
 CREATE INDEX IF NOT EXISTS idx_incidents_co_staff ON incidents USING gin(co_staff);


### PR DESCRIPTION
## Summary
- ensure migrations restore `co_staff` values when column is recreated

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684253ea5e98832bb29c598699f76dfb