### PR TITLE
Add Supabase auto-sync setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,16 @@ the same values across environments.
 
 When running on StackBlitz or locally, place these values in a `.env` file. On Vercel set them in your project settings.
 
+## GitHub + Supabase Auto-Sync
+
+Run `scripts/setupAutoSync.sh` to initialize Supabase and configure a `post-merge`
+git hook that fetches the latest `main` branch and applies migrations
+automatically. Edit `YOUR_PROJECT_REF` inside the script before running it:
+
+```bash
+bash scripts/setupAutoSync.sh
+```
+
 ## License
 
 MIT

--- a/scripts/setupAutoSync.sh
+++ b/scripts/setupAutoSync.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# ⚡️ TEAMWORK: Auto-Sync GitHub + Supabase Integration Script
+# ✨ Created: 2025-06-06T03:38:33Z
+# Use inside Codex or Bolt terminal or as a setup script for full sync automation
+
+# 1. Initialize Supabase if not done yet
+npx supabase init
+
+# 2. Set up live Supabase CLI linking to project
+supabase link --project-ref YOUR_PROJECT_REF
+
+# Optional: Store credentials securely for smoother automation
+# echo "SUPABASE_ACCESS_TOKEN=your-token-here" >> .env
+
+# 3. Set up Git post-merge hook (auto-fetch + hard reset after each merge)
+cat <<'HOOK' > .git/hooks/post-merge
+#!/bin/sh
+git fetch origin
+git reset --hard origin/main
+npx supabase db push
+HOOK
+
+chmod +x .git/hooks/post-merge
+
+# 4. Push latest migrations automatically to Supabase
+npx supabase db push
+


### PR DESCRIPTION
## Summary
- add `setupAutoSync.sh` script with post-merge Git hook and Supabase commands
- document how to run the script in README

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68426431d3f4832b8ecd20a57b1fe2e2