### PR TITLE
Add Bolt dev mode instructions

### DIFF
--- a/bolt.yaml
+++ b/bolt.yaml
@@ -68,3 +68,10 @@ performance:
   cache_static_assets: true
   compress_responses: true
   lazy_load_components: true
+meta:
+  instructions: |
+    # Bolt Development Mode Rule
+    When running Bolt in test or development mode:
+      1. Save the production-ready code before applying temporary changes.
+      2. After testing (e.g., CAPTCHA bypass), restore the original functional code.
+      3. Follow KEYBRIDGE codex in `tasks/keybridge_sync.md` and all project rules.

--- a/tasks/bolt_dev_mode_rule.md
+++ b/tasks/bolt_dev_mode_rule.md
@@ -1,0 +1,10 @@
+# ⚙️ Bolt Development Mode Rule
+
+When executing Bolt tasks in **test** or **development** mode, always preserve the real production code used for the final build.
+
+1. **Save Production Code**: Before applying any temporary test modifications (such as CAPTCHA bypass), commit or copy the current production-ready code.
+2. **Run Tests Safely**: Perform your development or test run. If the flow works, continue.
+3. **Restore Production State**: After testing, immediately restore the saved code so the repository reflects the functional version that will be built.
+4. **Follow KEYBRIDGE Codex**: Ensure these steps respect `tasks/keybridge_sync.md` and any other Codex rules throughout the project.
+
+This rule keeps development experiments from polluting the final build while remaining compliant with the KEYBRIDGE platform sync protocol.


### PR DESCRIPTION
## Summary
- create `bolt_dev_mode_rule.md` for preserving code when testing in Bolt
- append a `meta.instructions` block to `bolt.yaml` with the new rule

## Testing
- `npx vitest run` *(fails: res.setHeader is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6843a143e430832b9079ad4785ea2226